### PR TITLE
Remove ESLint warning in seeds and controllers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,4 +25,12 @@ module.exports = {
     'react/state-in-constructor': 'off',
     'react/no-access-state-in-setstate': 'off',
   },
+  overrides: [
+    {
+      files: ['**/seeds/**/*.js', '**/controllers/**/*.js'],
+      rules: {
+        '@typescript-eslint/camelcase': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
# Description

Remove warning about _ in identifiers in seeds and controllers.

# How to test?

Test by having an identifier in those files with _.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
