### PR TITLE
API endpoint for the deletion of a specific event that is not past.

### DIFF
--- a/src/server/api/controllers/events.controller.js
+++ b/src/server/api/controllers/events.controller.js
@@ -43,8 +43,34 @@ const getEventById = async (id) => {
   }
 };
 
+const deleteEvent = async (userId, eventId) => {
+  const user = await knex('users')
+    .select(
+      'users.name',
+      'users.id',
+      'user_id',
+      'role_id',
+      'roles.name as role_name',
+    )
+    .join('user_roles', 'users.id', 'user_roles.user_id')
+    .join('roles', 'user_roles.role_id', 'roles.id')
+    .where('users.id', userId)
+    .first();
+  if (user && user.role_name === 'Admin') {
+    const today = moment().format('YYYY-MM-DD HH:mm:ss');
+    await knex('events')
+      .where('id', eventId)
+      .where('event_date', '>', today)
+      .whereNull('deleted_at')
+      .update({ deleted_at: today });
+  } else {
+    throw new Error('Unauthorized', 403);
+  }
+};
+
 module.exports = {
   createEvent,
   getEvents,
   getEventById,
+  deleteEvent,
 };

--- a/src/server/api/controllers/events.controller.js
+++ b/src/server/api/controllers/events.controller.js
@@ -1,5 +1,6 @@
 const knex = require('../../config/db');
 const Error = require('../lib/utils/http-error');
+const moment = require('moment-timezone');
 
 const createEvent = async (body) => {
   await knex('events').insert({

--- a/src/server/api/routes/events.router.js
+++ b/src/server/api/routes/events.router.js
@@ -125,7 +125,6 @@ router.get('/:id', (req, res, next) => {
  *        description: Unexpected error.
  */
 router.delete('/:userId/:eventId', (req, res) => {
-  console.log(req.params);
   eventsController
     .deleteEvent(req.params.userId, req.params.eventId)
     .then((result) => {

--- a/src/server/api/routes/events.router.js
+++ b/src/server/api/routes/events.router.js
@@ -104,4 +104,38 @@ router.get('/:id', (req, res, next) => {
     .catch(next);
 });
 
+/**
+ * @swagger
+ * /events/{userId}/{eventId}:
+ *  delete:
+ *    summary: Delete an event
+ *    description:
+ *      Will delete a specific event with a given ID.
+ *    produces: application/json
+ *    parameters:
+ *      - in: path
+ *        name: userId
+ *      - in: path
+ *        name: eventId
+ *        description: ID of the event to delete.
+ *    responses:
+ *      200:
+ *        description: Event deleted
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.delete('/:userId/:eventId', (req, res) => {
+  console.log(req.params);
+  eventsController
+    .deleteEvent(req.params.userId, req.params.eventId)
+    .then((result) => {
+      if (result === 0) {
+        res.status(404).send('The event ID you provided does not exist.');
+      } else {
+        res.json({ success: true });
+      }
+    })
+    .catch((error) => console.log(error));
+});
+
 module.exports = router;


### PR DESCRIPTION
# Description

This API will delete an event that is in the future and the deletion process can only be done by an Admin. Or else it will throw an error 403 if the person trying to perform the delete is not an admin.

Fixes #137

# How to test?

swagger

# Checklist

- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] This PR is ready to be merged and not breaking any other functionality
