### PR TITLE
API: create, update, delete topics

### DIFF
--- a/src/server/api/controllers/topics.controller.js
+++ b/src/server/api/controllers/topics.controller.js
@@ -28,17 +28,35 @@ const getTopicById = async (id) => {
 };
 
 const editTopic = async (topicId, body) => {
-  return knex('topics')
-    .where({ id: topicId })
-    .update({
-      topic_name: body.topicName,
-      created_at: moment(body.created_at).format(),
-      updated_at: moment(body.updated_at).format(),
-    });
+  let timestamp = moment().format('YYYY-MM-DD HH:mm:ss');
+  return knex('topics').where({ id: topicId }).update({
+    topic_name: body.topicName,
+    created_at: timestamp,
+    updated_at: timestamp,
+  });
 };
 
 const deleteTopic = async (topicId) => {
-  return knex('topics').where({ id: topicId }).del();
+  try {
+    const topics = await knex('topics')
+      .select('topics.deleted_at as id', 'topics.topic_name as topicName')
+      .where({ id: topicId })
+      .andWhere({ deleted_at: null });
+    if (topics.length === 0) {
+      throw new Error(
+        `incorrect entry with the id of ${id} or the entry is deleted`,
+        404,
+      );
+    } else {
+      return knex('topics')
+        .where({ id: topicId })
+        .update({
+          deleted_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+        });
+    }
+  } catch (error) {
+    return error.message;
+  }
 };
 
 const createTopic = async (body) => {
@@ -49,8 +67,6 @@ const createTopic = async (body) => {
     lesson_url: body.lessonUrl,
     homework_url: body.homeworkUrl,
     module_id: body.moduleId,
-    created_at: moment(body.created_at).format(),
-    updated_at: moment(body.updated_at).format(),
   });
 
   return {

--- a/src/server/api/controllers/topics.controller.js
+++ b/src/server/api/controllers/topics.controller.js
@@ -1,5 +1,6 @@
 const knex = require('../../config/db');
 const Error = require('../lib/utils/http-error');
+const moment = require('moment-timezone');
 
 const getTopics = async () => {
   try {
@@ -26,7 +27,41 @@ const getTopicById = async (id) => {
   }
 };
 
+const editTopic = async (topicId, body) => {
+  return knex('topics')
+    .where({ id: topicId })
+    .update({
+      topic_name: body.topicName,
+      created_at: moment(body.created_at).format(),
+      updated_at: moment(body.updated_at).format(),
+    });
+};
+
+const deleteTopic = async (topicId) => {
+  return knex('topics').where({ id: topicId }).del();
+};
+
+const createTopic = async (body) => {
+  await knex('topics').insert({
+    topic_name: body.topicName,
+    week_number: body.weekNumber,
+    readme_url: body.readmeUrl,
+    lesson_url: body.lessonUrl,
+    homework_url: body.homeworkUrl,
+    module_id: body.moduleId,
+    created_at: moment(body.created_at).format(),
+    updated_at: moment(body.updated_at).format(),
+  });
+
+  return {
+    successful: true,
+  };
+};
+
 module.exports = {
   getTopics,
   getTopicById,
+  editTopic,
+  deleteTopic,
+  createTopic,
 };

--- a/src/server/api/controllers/topics.controller.js
+++ b/src/server/api/controllers/topics.controller.js
@@ -31,7 +31,11 @@ const editTopic = async (topicId, body) => {
   const timestamp = moment().format('YYYY-MM-DD HH:mm:ss');
   return knex('topics').where({ id: topicId }).update({
     topic_name: body.topicName,
-    created_at: timestamp,
+    week_number: body.weekNumber,
+    readme_url: body.readmeUrl,
+    lesson_url: body.lessonUrl,
+    homework_url: body.homeworkUrl,
+    module_id: body.moduleId,
     updated_at: timestamp,
   });
 };

--- a/src/server/api/controllers/topics.controller.js
+++ b/src/server/api/controllers/topics.controller.js
@@ -43,10 +43,7 @@ const deleteTopic = async (topicId) => {
       .where({ id: topicId })
       .andWhere({ deleted_at: null });
     if (topics.length === 0) {
-      throw new Error(
-        `incorrect entry with the id of ${id} or the entry is deleted`,
-        404,
-      );
+      throw new Error(`incorrect entry with the id of ${topicId}`, 404);
     } else {
       return knex('topics')
         .where({ id: topicId })

--- a/src/server/api/controllers/topics.controller.js
+++ b/src/server/api/controllers/topics.controller.js
@@ -28,7 +28,7 @@ const getTopicById = async (id) => {
 };
 
 const editTopic = async (topicId, body) => {
-  let timestamp = moment().format('YYYY-MM-DD HH:mm:ss');
+  const timestamp = moment().format('YYYY-MM-DD HH:mm:ss');
   return knex('topics').where({ id: topicId }).update({
     topic_name: body.topicName,
     created_at: timestamp,

--- a/src/server/api/routes/topics.router.js
+++ b/src/server/api/routes/topics.router.js
@@ -123,6 +123,16 @@ router.post('/', (req, res) => {
  *          properties:
  *            topicName:
  *              type: string
+ *            weekNumber:
+ *              type: integer
+ *            readmeUrl:
+ *              type: varchar
+ *            lessonUrl:
+ *              type: varchar
+ *            homeworkUrl:
+ *              type: varchar
+ *            moduleId:
+ *              type: integer
  *    responses:
  *      200:
  *        description: Topic was patched

--- a/src/server/api/routes/topics.router.js
+++ b/src/server/api/routes/topics.router.js
@@ -75,8 +75,6 @@ router.get('/:id', (req, res, next) => {
  *            - lessonUrl
  *            - homeworkUrl
  *            - moduleId
- *            - created_at
- *            - updated_at
  *          properties:
  *            topicName:
  *              type: string
@@ -90,12 +88,6 @@ router.get('/:id', (req, res, next) => {
  *              type: varchar
  *            moduleId:
  *              type: integer
- *            created_at:
- *              type: string
- *              format: date-time
- *            updated_at:
- *              type: string
- *              format: date-time
  *    responses:
  *      200:
  *        description: Successful request
@@ -106,9 +98,7 @@ router.post('/', (req, res) => {
   topicsController
     .createTopic(req.body)
     .then((result) => res.json(result))
-    .catch((error) => {
-      console.log(error);
-
+    .catch(() => {
       res.status(400).send('Bad request').end();
     });
 });
@@ -133,12 +123,6 @@ router.post('/', (req, res) => {
  *          properties:
  *            topicName:
  *              type: string
- *            created_at:
- *              type: string
- *              format: date-time
- *            updated_at:
- *              type: string
- *              format: date-time
  *    responses:
  *      200:
  *        description: Topic was patched

--- a/src/server/api/routes/topics.router.js
+++ b/src/server/api/routes/topics.router.js
@@ -54,4 +54,134 @@ router.get('/:id', (req, res, next) => {
     .catch(next);
 });
 
+/**
+ * @swagger
+ * /topics:
+ *  post:
+ *    summary: Create a topic
+ *    description:
+ *      Will create a topic.
+ *    produces: application/json
+ *    parameters:
+ *      - in: body
+ *        name: topic
+ *        description: The topic to create.
+ *        schema:
+ *          type: object
+ *          required:
+ *            - topicName
+ *            - weekNumber
+ *            - readmeUrl
+ *            - lessonUrl
+ *            - homeworkUrl
+ *            - moduleId
+ *            - created_at
+ *            - updated_at
+ *          properties:
+ *            topicName:
+ *              type: string
+ *            weekNumber:
+ *              type: integer
+ *            readmeUrl:
+ *              type: varchar
+ *            lessonUrl:
+ *              type: varchar
+ *            homeworkUrl:
+ *              type: varchar
+ *            moduleId:
+ *              type: integer
+ *            created_at:
+ *              type: string
+ *              format: date-time
+ *            updated_at:
+ *              type: string
+ *              format: date-time
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.post('/', (req, res) => {
+  topicsController
+    .createTopic(req.body)
+    .then((result) => res.json(result))
+    .catch((error) => {
+      console.log(error);
+
+      res.status(400).send('Bad request').end();
+    });
+});
+
+/**
+ * @swagger
+ * /topics/{ID}:
+ *  patch:
+ *    summary: Create a topic
+ *    description:
+ *      Will create a topic.
+ *    produces: application/json
+ *    parameters:
+ *      - in: path
+ *        name: ID
+ *        description: ID of the topic to patch.
+ *      - in: body
+ *        name: topic
+ *        description: The topic to create.
+ *        schema:
+ *          type: object
+ *          properties:
+ *            topicName:
+ *              type: string
+ *            created_at:
+ *              type: string
+ *              format: date-time
+ *            updated_at:
+ *              type: string
+ *              format: date-time
+ *    responses:
+ *      200:
+ *        description: Topic was patched
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.patch('/:id', (req, res, next) => {
+  topicsController
+    .editTopic(req.params.id, req.body)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+/**
+ * @swagger
+ * /topics/{ID}:
+ *  delete:
+ *    summary: Delete a topic
+ *    description:
+ *      Will delete a topic with a given ID.
+ *    produces: application/json
+ *    parameters:
+ *      - in: path
+ *        name: ID
+ *        description: ID of the topic to delete.
+ *    responses:
+ *      200:
+ *        description: Topic deleted
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.delete('/:id', (req, res) => {
+  topicsController
+    .deleteTopic(req.params.id, req)
+    .then((result) => {
+      // If result is equal to 0, then that means the topic id does not exist
+      if (result === 0) {
+        res.status(404).send('The topic ID you provided does not exist.');
+      } else {
+        res.json({ success: true });
+      }
+    })
+    .catch((error) => console.log(error));
+});
+
 module.exports = router;


### PR DESCRIPTION
# Description

This issue is about API endpoints create, update and delete topics.

Fixes # (219)

# How to test?

Tested this in swagger and in database. 


# Checklist

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] This PR is ready to be merged and not breaking any other functionality
