### PR TITLE
Endpoint to retrieve all future events for a user

### DIFF
--- a/src/server/api/controllers/eventsUsers.controller.js
+++ b/src/server/api/controllers/eventsUsers.controller.js
@@ -1,0 +1,87 @@
+const knex = require('../../config/db');
+const moment = require('moment-timezone');
+
+function getNumberOfWeek(date) {
+  const today = date;
+  const firstDayOfYear = new Date(today.getFullYear(), 0, 1);
+  const pastDaysOfYear = (today - firstDayOfYear) / 86400000;
+  return Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);
+}
+
+const getUserEventsByUID = async (userID, role) => {
+  const today = moment().format('YYYY-MM-DD HH:mm:ss');
+  /* 
+SQL query to select .... all the future and ongoing events for a userId
+
+select events.id, organizations.name,events.event_date 
+from events 
+join events_users 
+	on events.id = events_users.event_id 
+join users 
+	on events_users.users_id = users.id
+join organizations
+	on users.organization_id = organizations.id
+where users.id=4 and event_date>"2020-11-18 10:00:00"
+
+SQL query to get role name for a userID
+
+SELECT roles.name
+FROM users 
+join user_roles on users.id = user_roles.user_id 
+join roles on user_roles.role_id = roles.id
+where users.id=3;
+  */
+  try {
+    const userEvents = await knex('events')
+      .select(
+        'events.id as eventID',
+        'organizations.name as organization',
+        'events.event_date as dateTime',
+      )
+      .join('events_users', 'events.id', 'events_users.event_id')
+      .join('users', 'events_users.users_id', 'users.id')
+      .join('organizations', 'users.organization_id', 'organizations.id')
+      .where('users.id', userID)
+      .where('event_date', '>', today);
+    // userEvents has all the events for a user id
+    // now check the role of the user
+
+    const userRole = await knex('users')
+      .select('roles.name')
+      .join('user_roles', 'users.id', 'user_roles.user_id')
+      .join('roles', 'user_roles.role_id', 'roles.id')
+      .where('users.id', 3);
+
+    /* modify userEvents as per our requirement
+     1. Event Id
+    2. Organization hosting the event/study group,
+    3. Date of the event/study group
+    4. Time of the event/study group,
+    5. Week number */
+
+    const formatedUserEvents = userEvents.map((userEvent) => ({
+      eventID: userEvent.eventID,
+      organization: userEvent.organization,
+      date: `${userEvents[0].dateTime.getDate()}-${
+        userEvents[0].dateTime.getMonth() + 1
+      }-${userEvents[0].dateTime.getFullYear()}`,
+      time: `${userEvents[0].dateTime.getHours()}:${userEvents[0].dateTime.getMinutes()}:${userEvents[0].dateTime.getSeconds()}`,
+      weekNumber: `${getNumberOfWeek(userEvents[0].dateTime)}`,
+    }));
+
+    if (userEvents.length === 0) return ['no matching records found'];
+    if (role !== userRole) return ['incorrect role name in the url path'];
+    if (role === 'student') {
+      return ['should return mentors attending'];
+    }
+    if (role === 'mentor') {
+      return ['should return students attending'];
+    }
+    return formatedUserEvents;
+  } catch (error) {
+    return error.message;
+  }
+};
+module.exports = {
+  getUserEventsByUID,
+};

--- a/src/server/api/controllers/eventsUsers.controller.js
+++ b/src/server/api/controllers/eventsUsers.controller.js
@@ -69,14 +69,9 @@ where users.id=3;
       weekNumber: `${getNumberOfWeek(userEvents[0].dateTime)}`,
     }));
 
-    if (userEvents.length === 0) return ['no matching records found'];
-    if (role !== userRole) return ['incorrect role name in the url path'];
-    if (role === 'student') {
-      return ['should return mentors attending'];
-    }
-    if (role === 'mentor') {
-      return ['should return students attending'];
-    }
+    if (userEvents.length === 0) return [];
+    if (role !== userRole) return [];
+
     return formatedUserEvents;
   } catch (error) {
     return error.message;

--- a/src/server/api/routes/api-router.js
+++ b/src/server/api/routes/api-router.js
@@ -17,6 +17,7 @@ const groupsRouter = require('./groups.router');
 
 const feedbacksRouter = require('./feedbacks.router');
 const organizationsRouter = require('./organizations.router');
+const eventsUsersRouter = require('./eventsUsers.router');
 
 const slackRouter = require('./slack.router');
 
@@ -56,6 +57,7 @@ router.use('/groups', groupsRouter);
 router.use('/feedbacks', feedbacksRouter);
 
 router.use('/organizations', organizationsRouter);
+router.use('/eventsUsers', eventsUsersRouter);
 
 router.use('/signin', slackRouter);
 

--- a/src/server/api/routes/eventsUsers.router.js
+++ b/src/server/api/routes/eventsUsers.router.js
@@ -1,0 +1,44 @@
+/* The API routing for events users */
+
+const express = require('express');
+
+const router = express.Router({ mergeParams: true });
+
+// controllers
+const eventsUsersController = require('../controllers/eventsUsers.controller');
+
+/**
+ * @swagger
+ * /eventsUsers/{userID}/{role}:
+ *  get:
+ *    summary: Get events by a user with userID
+ *    description:
+ *      Will return  events with a matching userID.
+ *    produces: application/json
+ *    parameters:
+ *     - in: path
+ *       name: userID
+ *       schema:
+ *         type: integer
+ *         required: true
+ *         description: The userID of the event to get
+ *     - in: path
+ *       name: role
+ *       schema:
+ *         type: string
+ *         required: true
+ *         description: The userID of the event to get
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.get('/:userID/:role', (req, res, next) => {
+  eventsUsersController
+    .getUserEventsByUID(req.params.userID, req.params.role)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+module.exports = router;


### PR DESCRIPTION
# Description
API: Endpoint to retrieve all the registered and future events for a specific user. At the moment it returns
1.Event Id
2.Organisation hosting the event/study group,
3.Date of the event/study group
4.Time of the event/study group,
5.Week number
and further has to work on 
6.1. mentors attending if the requesting user is a student
. or
6.2 the list of students if the requesting user is a mentor.

    

Fixes #84 

# How to test?

It can be  tested with swagger.

 note: in knex..select instead of today give any existing date in database
comment one of the statement to see the result
    if (role !== userRole) return ['incorrect role name in the url path'];
  
![image](https://user-images.githubusercontent.com/60918335/103193211-093e1280-48dc-11eb-8d2f-a24dc0168553.png)
  

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR is ready to be merged and not breaking any other functionality
