### PR TITLE
 Create a page that will list all topics #261

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -11,6 +11,7 @@ import EventsPage from './containers/EventsPage/EventsPage';
 import { Home } from './containers/Home/Home';
 import LoginPage from './containers/LoginPage/LoginPage.component';
 import LoginTest from './containers/LoginTestPage';
+import TopicsTest from './containers/TopicsPage/TopicsPage';
 import ProfilePage from './containers/ProfilePage/ProfilePage.component';
 import { MentorProfilePage } from './containers/ProfilePage/MentorProfile/MentorProfile.component';
 import { StudentProfilePage } from './containers/ProfilePage/StudentProfile/StudentProfile/StudentProfile.component';
@@ -74,7 +75,9 @@ function App() {
         <AuthenticatedRoute exact path="/events">
           <EventsPage />
         </AuthenticatedRoute>
-
+        <Route exact path="/topics">
+          <TopicsTest />
+        </Route>
         <AuthenticatedRoute exact path="/profile">
           <ProfilePage />
         </AuthenticatedRoute>

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -75,9 +75,9 @@ function App() {
         <AuthenticatedRoute exact path="/events">
           <EventsPage />
         </AuthenticatedRoute>
-        <Route exact path="/topics">
+        <AuthenticatedRoute exact path="/topics">
           <TopicsTest />
-        </Route>
+        </AuthenticatedRoute>
         <AuthenticatedRoute exact path="/profile">
           <ProfilePage />
         </AuthenticatedRoute>

--- a/src/client/containers/TopicsPage/TopicsPage.js
+++ b/src/client/containers/TopicsPage/TopicsPage.js
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+import { Layout } from '../../components/Layout';
+import Footer from '../../components/footer/footer';
+import { AppHeader } from '../../components/Appheader/AppHeader.component';
+import { AdminAvatar } from '../../components/Avatar';
+import Heading from '../../components/Heading/Heading';
+import Label from '../../components/Label/Tags/Label';
+import { useAuthenticatedFetch } from '../../hooks/useAuthenticatedFetch';
+
+export default function TopicsPage() {
+  const [topics, setTopics] = useState([]);
+  const { fetch } = useAuthenticatedFetch();
+
+  useEffect(() => {
+    fetch('/api/topics').then((data) => {
+      setTopics(data);
+      console.log(data);
+    });
+  }, [fetch]);
+
+  return (
+    <Layout>
+      <AppHeader />
+      <div className="admin-registration-avatar">
+        <AdminAvatar />
+      </div>
+      <Heading>Welcome Admin</Heading>
+      <div className="topic-lable">
+        {topics.map((topic) => (
+          <Label text={topic.topicName} />
+        ))}
+      </div>
+      <Footer id="footer" />
+    </Layout>
+  );
+}

--- a/src/client/containers/TopicsPage/TopicsPage.js
+++ b/src/client/containers/TopicsPage/TopicsPage.js
@@ -4,7 +4,6 @@ import Footer from '../../components/footer/footer';
 import { AppHeader } from '../../components/Appheader/AppHeader.component';
 import { AdminAvatar } from '../../components/Avatar';
 import Heading from '../../components/Heading/Heading';
-import Label from '../../components/Label/Tags/Label';
 import { useAuthenticatedFetch } from '../../hooks/useAuthenticatedFetch';
 
 export default function TopicsPage() {
@@ -27,7 +26,7 @@ export default function TopicsPage() {
       <Heading>Welcome Admin</Heading>
       <div className="topic-lable">
         {topics.map((topic) => (
-          <Label text={topic.topicName} />
+          <span> {topic.topicName} </span>
         ))}
       </div>
       <Footer id="footer" />

--- a/src/client/containers/TopicsPage/TopicsPage.js
+++ b/src/client/containers/TopicsPage/TopicsPage.js
@@ -26,7 +26,7 @@ export default function TopicsPage() {
       <Heading>Welcome Admin</Heading>
       <div className="topic-lable">
         {topics.map((topic) => (
-          <span> {topic.topicName} </span>
+          <span key={topic.id}> {topic.topicName} </span>
         ))}
       </div>
       <Footer id="footer" />

--- a/src/client/containers/TopicsPage/TopicsPage.js
+++ b/src/client/containers/TopicsPage/TopicsPage.js
@@ -13,7 +13,6 @@ export default function TopicsPage() {
   useEffect(() => {
     fetch('/api/topics').then((data) => {
       setTopics(data);
-      console.log(data);
     });
   }, [fetch]);
 


### PR DESCRIPTION
# Description

This is the PR for a new page under `/admin/topics` which will fetch the list of topics from the API and display them

Fixes # (261)

# How to test?

# Checklist

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] This PR is ready to be merged and not breaking any other functionality
